### PR TITLE
bump rpc version to 2.0

### DIFF
--- a/pahkat-rpc/Cargo.toml
+++ b/pahkat-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pahkat-rpc"
-version = "0.1.7"
+version = "2.0.0"
 authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 edition = "2018"
 


### PR DESCRIPTION
This is to match the version of divvun-manager