### PR TITLE
Always install dependencies on macos

### DIFF
--- a/pahkat-client-core/README.md
+++ b/pahkat-client-core/README.md
@@ -10,6 +10,12 @@ Includes a command line tool.
 
 If you want `xz2-rs` to statically link, add `LZMA_API_STATIC=1` to your environment before building.
 
+## Notes
+
+### MacOS
+The MacOS service is using `pkgutil` to determine the status of installed packages and their dependencies. If files get manually deleted, `pkgutil` will not realize that and potentially report a package to be up to date even though it got deleted.
+As a workaround, dependencies always get installed on MacOS. Packages that appear up to date but don't work need to be reinstalled.
+
 ## License
 
 ISC license - see LICENSE file.

--- a/pahkat-client-core/src/repo.rs
+++ b/pahkat-client-core/src/repo.rs
@@ -1044,7 +1044,14 @@ pub(crate) fn resolve_package_set(
             if candidate.action == PackageActionType::Install
                 && candidate.status == PackageStatus::UpToDate
             {
-                None
+                // We can not trust the UpToDate status on MacOS. If a dependency gets manually deleted, 
+                // it might appear up to date to pahkat but in fact, does not exist. 
+                // So it needs to be installed every time.
+                if cfg!(target_os = "macos") {
+                    Some(candidate)
+                } else {
+                    None
+                }
             } else if candidate.action == PackageActionType::Uninstall
                 && candidate.status == PackageStatus::NotInstalled
             {


### PR DESCRIPTION
If a dependency (e.g. MacDivvun) gets manually deleted pahkat still things it's up to date and therefore never gets reinstalled. As a workaround dependencies always get installed even if they already exist.