### PR TITLE
Feature/manifest toml

### DIFF
--- a/pahkat-uploader/Cargo.lock
+++ b/pahkat-uploader/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pahkat-types"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "fbs",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "pahkat-uploader"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "pahkat-types",

--- a/pahkat-uploader/README.md
+++ b/pahkat-uploader/README.md
@@ -15,3 +15,46 @@ Uploading a `metadata.toml` file looks like this (also taken from CI):
 ```bash
 pahkat-uploader upload -u https://pahkat.thetc.se/main/packages/keyboard-fit -P ./metadata.toml
 ```
+
+### Adding additional metadata to the release
+
+As of version 2.XXXXXX it's possible to update a package's `name` and `description` fields.
+
+There are 2 ways to do this:
+1. Using the `--metadata-json` option to supply a json file (see format below)
+2. Using the `--additional-meta` option to supply a toml file (see format below)
+
+#### Supplying `name` and `description` data via json
+This is currently used when uploading keyboard releases. The json file you provide with the `--metadata-json` option should be formatted like this:
+```json
+{
+  "fit": {
+    "name": "Meänkieli-näppäimistöt",
+    "description": "Näppäimistöt Meänkielille UiT:n Divvun-ryhmästä ja Giellatekno-ryhmästä."
+  },
+  "en": {
+    "name": "Meänkieli Keyboards",
+    "description": "Keyboards for the Meänkieli language from the Divvun and Giellatekno groups at UiT."
+  },
+  "nb": {
+    "name": "Meänkieli tastatur",
+    "description": "Tastatur for Meänkieli fra Divvun-gruppa ved UiT."
+  }
+  ...
+}
+```
+`pahkat-uploader` will convert it to the necessary format. This format is used because it's what is used in [`xxx.kbdgen/project.yaml`](https://github.com/giellalt/keyboard-fit/blob/main/fit.kbdgen/project.yaml)
+
+#### Supplying `name` and `description` data via toml
+This is currently used when uploaded spellers, and will later be expanded to include grammar checkers and speech synthesis. The toml file you provide with the `--additional-meta` should be formatted like this:
+```toml
+[name]
+en = "name"
+sv = "namn"
+...
+
+[description]
+en = "description"
+sv = "beskrivning"
+...
+```

--- a/pahkat-uploader/README.md
+++ b/pahkat-uploader/README.md
@@ -2,7 +2,7 @@
 
 `pahkat-uploader` is a command line utility that has two responsibilities:
 1. Creating a `metadata.toml` for a release to be uploaded to a pahkat index using [`pahkat-reposrv`](https://github.com/divvun/pahkat-reposrv).
-2. Uploading the `metadata.toml` generated in step 1 via `pahkat-reposrv`.
+2. Uploading the `metadata.toml` generated in step 1, along with optional other metadata, via `pahkat-reposrv`.
 
 It is used by CI to do both of the above.
 
@@ -18,14 +18,14 @@ pahkat-uploader upload -u https://pahkat.thetc.se/main/packages/keyboard-fit -P 
 
 ### Adding additional metadata to the release
 
-As of version 2.XXXXXX it's possible to update a package's `name` and `description` fields.
+As of version 2.3 it's possible to update a package's `name` and `description` fields.
 
 There are 2 ways to do this:
-1. Using the `--metadata-json` option to supply a json file (see format below)
-2. Using the `--additional-meta` option to supply a toml file (see format below)
+1. Using the `--metadata-json` option to supply a json file, used for keyboards
+2. Using the `--manifest-toml` option to supply a toml file and the `--package-type` option to supply package type (at the time of this writing, only `speller` is supported. It will be expanded to include grammar checkers and other types in the future.) 
 
-#### Supplying `name` and `description` data via json
-This is currently used when uploading keyboard releases. The json file you provide with the `--metadata-json` option should be formatted like this:
+#### Supplying additional metadata for keyboard releases
+The json file you provide with the `--metadata-json` option should be formatted like this:
 ```json
 {
   "fit": {
@@ -43,18 +43,30 @@ This is currently used when uploading keyboard releases. The json file you provi
   ...
 }
 ```
-`pahkat-uploader` will convert it to the necessary format. This format is used because it's what is used in [`xxx.kbdgen/project.yaml`](https://github.com/giellalt/keyboard-fit/blob/main/fit.kbdgen/project.yaml)
+`pahkat-uploader` will convert it to the necessary format. This format is used because it's the format used by [`xxx.kbdgen/project.yaml`](https://github.com/giellalt/keyboard-fit/blob/main/fit.kbdgen/project.yaml) files.
 
-#### Supplying `name` and `description` data via toml
-This is currently used when uploaded spellers, and will later be expanded to include grammar checkers and speech synthesis. The toml file you provide with the `--additional-meta` should be formatted like this:
+A full command that supplies a `metadata.json` might look like this:
+
+```bash
+pahkat-uploader upload -u https://pahkat.thetc.se/main/packages/keyboard-fit --release-meta ./metadata.toml --metadata-json ./metadata.json
+```
+
+#### Supplying additional metadata when for `lang-xxx` releases (spellers, grammar checkers, etc) via `manifest.toml`
+This is currently used when uploading spellers, and will later be expanded to include grammar checkers and other types. The toml file you provide with the `--manifest-toml` option should be formatted like this:
 ```toml
-[name]
+[speller.name]
 en = "name"
 sv = "namn"
 ...
 
-[description]
+[speller.description]
 en = "description"
 sv = "beskrivning"
 ...
+```
+
+A full command that supplies a `manifest.toml` might look like:
+
+```bash
+pahkat-uploader upload --url http://test.com  --release-meta release-meta.toml --manifest-toml manifest.toml --package-type speller
 ```

--- a/pahkat-uploader/manifest-test.toml
+++ b/pahkat-uploader/manifest-test.toml
@@ -1,0 +1,19 @@
+version = "0.1.1"
+
+[speller.name]
+en = "Meänkieli"
+fi = "Meänkieli"
+
+[speller.description]
+en = "Meänkieli spellchecker"
+fi = "Meänkieli oikolukija"
+
+[macos]
+system_pkg_id = "no.divvun.MacDivvun.fit"
+
+[windows]
+system_product_code = "{77575EA4-966E-4F26-B956-06FC1CE3C3D6}_is1"
+legacy_product_codes = [
+    { value = "47877A58-DF15-40AF-ABB4-C6C2CE41EE2D", kind = "nsis" },
+    { value = "8F506290-ECCD-484E-B335-63DFDB31245D", kind = "nsis" }
+]

--- a/pahkat-uploader/metadata.json
+++ b/pahkat-uploader/metadata.json
@@ -1,0 +1,14 @@
+{
+    "fit": {
+      "name": "Meänkieli-näppäimistöt",
+      "description": "Näppäimistöt Meänkielille UiT:n Divvun-ryhmästä ja Giellatekno-ryhmästä."
+    },
+    "en": {
+      "name": "Meänkieli Keyboards",
+      "description": "Keyboards for the Meänkieli language from the Divvun and Giellatekno groups at UiT."
+    },
+    "nb": {
+      "name": "Meänkieli tastatur",
+      "description": "Tastatur for Meänkieli fra Divvun-gruppa ved UiT."
+    }
+}

--- a/pahkat-uploader/payload.toml
+++ b/pahkat-uploader/payload.toml
@@ -1,6 +1,0 @@
-type = 'MacOSPackage'
-url = 'http://test/'
-pkg_id = 'test'
-size = 1
-installed_size = 1
-

--- a/pahkat-uploader/release-meta.toml
+++ b/pahkat-uploader/release-meta.toml
@@ -1,0 +1,22 @@
+version = '1.0'
+channel = 'nightly'
+
+[target]
+platform = 'macos'
+
+[target.dependencies]
+
+[target.payload]
+type = 'MacOSPackage'
+url = 'http://test/'
+pkg_id = 'test'
+targets = [
+'system',
+'user',
+]
+requires_reboot = [
+'install',
+'uninstall',
+]
+size = 1
+installed_size = 1

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -136,8 +136,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn names_and_descs(release: &mut Release, path: &Path) -> Result<()> {
-    let metadata = std::fs::read_to_string(path)?;
+fn names_and_descs(release: &mut Release, metadata_json: &Path) -> Result<()> {
+    let metadata = std::fs::read_to_string(metadata_json)?;
     // assume json is like: {en: {name: "", description: ""}}
     let metadata: BTreeMap<String, BTreeMap<String, String>> = serde_json::from_str(&metadata)?;
     // convert to {name: {en: ""}, description: {en: ""}}

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -12,7 +12,7 @@ struct Upload {
     pub url: String,
 
     #[structopt(short = "P", long)]
-    pub release_meta_path: PathBuf,
+    pub release_meta: PathBuf,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[structopt(short, long)]
@@ -72,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
             let auth =
                 std::env::var("PAHKAT_API_KEY").context("could not read env PAHKAT_API_KEY")?;
 
-            let release = std::fs::read_to_string(upload.release_meta_path)?;
+            let release = std::fs::read_to_string(upload.release_meta)?;
             let mut release: Release = toml::from_str(&release)?;
 
             if let Some(path) = upload.metadata_json {

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -161,7 +161,7 @@ fn names_and_descs(release: &mut Release, metadata_json: &Path) -> Result<()> {
 
     // DEBUG
     // dbg!(&release);
-    println!("{}", serde_json::to_string(&release)?);
+    // println!("{}", serde_json::to_string(&release)?);
     Ok(())
 }
 

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -178,10 +178,10 @@ struct SpellerMeta {
 
 fn names_and_descs_toml(
     release: &mut Release,
-    metadata_toml: &Path,
+    manifest_toml: &Path,
     package_type: &PackageType,
 ) -> Result<()> {
-    let manifest = std::fs::read_to_string(metadata_toml)?;
+    let manifest = std::fs::read_to_string(manifest_toml)?;
     let manifest: Manifest = toml::from_str(&manifest)?;
     let metadata = match package_type {
         PackageType::Speller => manifest.speller,

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -2,9 +2,16 @@ use anyhow::{Context, Result};
 use pahkat_types::LangTagMap;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use structopt::clap::arg_enum;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
+
+#[derive(StructOpt)]
+enum Args {
+    Release(Release),
+    Upload(Upload),
+}
 
 #[derive(StructOpt, Serialize, Deserialize)]
 struct Upload {
@@ -15,14 +22,24 @@ struct Upload {
     pub release_meta: PathBuf,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[structopt(short, long)]
+    #[structopt(long)]
     pub metadata_json: Option<PathBuf>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[structopt(long, requires("package-type"))]
+    pub manifest_toml: Option<PathBuf>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[structopt(long, possible_values = &PackageType::variants(), case_insensitive = true)]
+    pub package_type: Option<PackageType>,
 }
 
-#[derive(StructOpt)]
-enum Args {
-    Release(Release),
-    Upload(Upload),
+arg_enum! {
+    #[derive(Debug, Serialize, Deserialize)]
+    enum PackageType {
+        Speller,
+        // to be expanded with grammar checkers and other types in the future
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, structopt::StructOpt)]

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -2,9 +2,9 @@ use anyhow::{Context, Result};
 use pahkat_types::LangTagMap;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use structopt::clap::arg_enum;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use structopt::clap::arg_enum;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -167,7 +167,7 @@ fn names_and_descs(release: &mut Release, metadata_json: &Path) -> Result<()> {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Manifest {
-    speller: SpellerMeta
+    speller: SpellerMeta,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -176,7 +176,11 @@ struct SpellerMeta {
     description: BTreeMap<String, String>,
 }
 
-fn names_and_descs_toml(release: &mut Release, metadata_toml: &Path, package_type: &PackageType) -> Result<()> {
+fn names_and_descs_toml(
+    release: &mut Release,
+    metadata_toml: &Path,
+    package_type: &PackageType,
+) -> Result<()> {
     let manifest = std::fs::read_to_string(metadata_toml)?;
     let manifest: Manifest = toml::from_str(&manifest)?;
     let metadata = match package_type {

--- a/pahkat-uploader/src/main.rs
+++ b/pahkat-uploader/src/main.rs
@@ -172,8 +172,8 @@ struct Manifest {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct SpellerMeta {
-    name: BTreeMap<String, String>,
-    description: BTreeMap<String, String>,
+    name: LangTagMap<String>,
+    description: LangTagMap<String>,
 }
 
 fn names_and_descs_toml(


### PR DESCRIPTION
Adds the `--manifest-toml` and `--package-type` options for uploading a `manifest.toml` with the new format

```toml
[speller.name]
en = "name"
sv = "namn"

[speller.description]
en = "description"
sv = "beskrivning"
...
```

`pahkat-uploader` will pull out the `name` and `description` tables for the specified `--package-type`, and upload it via `pahkat-reposrv`. Currently only `speller` is supported as a package type. This will be expanded in the future.