### PR TITLE
Fix nightly updates

### DIFF
--- a/pahkat-client-core/src/cmp.rs
+++ b/pahkat-client-core/src/cmp.rs
@@ -8,12 +8,55 @@ pub(crate) fn cmp(
 ) -> Result<PackageStatus, PackageStatusError> {
     let installed_version = match Version::new(installed_version) {
         Ok(v) => v,
-        Err(_) => return Err(PackageStatusError::ParsingVersion),
+        Err(e) => {
+            log::warn!("Can't parse version {}, {:?}", installed_version, e);
+            return Err(PackageStatusError::ParsingVersion);
+        }
     };
 
     if candidate_version > &installed_version {
-        Ok(PackageStatus::RequiresUpdate)
-    } else {
-        Ok(PackageStatus::UpToDate)
+        return Ok(PackageStatus::RequiresUpdate);
     }
+
+    Ok(PackageStatus::UpToDate)
+}
+
+#[test]
+fn compare_versions() {
+    assert_eq!(
+        cmp("1.0.0", &Version::new("1.0.1").unwrap()).unwrap(),
+        PackageStatus::RequiresUpdate
+    );
+    assert_eq!(
+        cmp(
+            "1.0.0",
+            &Version::new("1.0.0-nightly.20240516T103300123Z").unwrap()
+        )
+        .unwrap(),
+        PackageStatus::UpToDate
+    );
+    assert_eq!(
+        cmp(
+            "1.0.0-nightly.20240516T103300123Z",
+            &Version::new("1.0.0").unwrap()
+        )
+        .unwrap(),
+        PackageStatus::RequiresUpdate
+    );
+    assert_eq!(
+        cmp(
+            "1.0.0",
+            &Version::new("1.0.1-nightly.20240516T103300123Z").unwrap()
+        )
+        .unwrap(),
+        PackageStatus::RequiresUpdate
+    );
+    assert_eq!(
+        cmp(
+            "1.0.1-nightly.20240516T103300123Z",
+            &Version::new("1.0.1-nightly.20241231T103300123Z").unwrap()
+        )
+        .unwrap(),
+        PackageStatus::RequiresUpdate
+    );
 }

--- a/pahkat-client-core/src/transaction/install.rs
+++ b/pahkat-client-core/src/transaction/install.rs
@@ -25,4 +25,7 @@ pub enum ProcessError {
 
     #[error("Unknown error")]
     Unknown(process::Output),
+
+    #[error("Plist error")]
+    Plist(#[from] plist::Error),
 }

--- a/pahkat-rpc/src/lib.rs
+++ b/pahkat-rpc/src/lib.rs
@@ -1010,7 +1010,7 @@ pub async fn start(
     );
 
     let endpoint = endpoint(path)?;
-    log::debug!("Endpoint created successfully.");
+    log::debug!("Endpoint created successfully `{:?}`.", path);
     let store = store(config_path).await?;
     log::debug!("Created store.");
 


### PR DESCRIPTION
Fixes a bug that prevented updating to a newer nightly of the same version number, (eg 1.0.0-nightly1 would not be updated when 1.0.0-nightly2 became available)

Related to https://github.com/divvun/divvun-manager-macos/issues/32 and https://github.com/divvun/divvun-manager-macos/issues/48

The decision was, instead of reimplementing parts of Pahkat to support packages coming from different channels, to leave as is (only support one channel at a time).

Now new versions of nightlies should update as expected.